### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ pkg/
 waffle/
 
 *.xz
+*.gz
 *.sig


### PR DESCRIPTION
Trivial update to handle all the misc artefacts left in the git repository. Fwiw waffle-git/src/waffle do stay around, but that's alot better than before :-)

Btw what what the reason behind moving from the waffle-gl.org_xz to github.com_gz tarballs ?
